### PR TITLE
Fix Metal function signature for popcount()

### DIFF
--- a/src/toMetalInstruction.cpp
+++ b/src/toMetalInstruction.cpp
@@ -2802,7 +2802,7 @@ void ToMetal::TranslateInstruction(Instruction* psInst)
 #endif
             psContext->AddIndentation();
             glsl << TranslateOperand(&psInst->asOperands[0], TO_FLAG_INTEGER | TO_FLAG_DESTINATION);
-            bcatcstr(glsl, " = popCount(");
+            bcatcstr(glsl, " = popcount(");
             glsl << TranslateOperand(&psInst->asOperands[1], TO_FLAG_INTEGER);
             bcatcstr(glsl, ");\n");
             break;


### PR DESCRIPTION
### Problem

I get the following error when trying to compile my compute shader on iOS:
```
Compilation failed: 

program_source:60:20: error: use of undeclared identifier 'popCount'; did you mean 'popcount'?
        u_xlatu4 = popCount(u_xlati4);
                   ^~~~~~~~
                   popcount
/System/Library/PrivateFrameworks/GPUCompiler.framework/./Libraries/lib/clang/902.1/include/metal/metal_integer:174:14: note: 'popcount' declared here
METAL_FUNC T popcount(T x)
```

When looking at the function signature for popcount it is indeed all lower-case: https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf (search for "popcount")

### Solution

Fix the problem in `toMetalInstruction.cpp`.

Is there any way for me to fix this locally in my build while I wait for this fix to propagate through the release cycle?