### PR TITLE
Fix decoding of INDEX_IMMEDIATE64_PLUS_RELATIVE

### DIFF
--- a/src/internal_includes/tokens.h
+++ b/src/internal_includes/tokens.h
@@ -433,7 +433,7 @@ typedef enum OPERAND_INDEX_REPRESENTATION
 
 static OPERAND_INDEX_REPRESENTATION DecodeOperandIndexRepresentation(uint32_t ui32Dimension, uint32_t ui32Token)
 {
-    return (OPERAND_INDEX_REPRESENTATION)((ui32Token & (0x3 << (22 + 3 * ((ui32Dimension) & 3)))) >> (22 + 3 * ((ui32Dimension) & 3)));
+    return (OPERAND_INDEX_REPRESENTATION)((ui32Token & (0x7 << (22 + 3 * ((ui32Dimension) & 3)))) >> (22 + 3 * ((ui32Dimension) & 3)));
 }
 
 typedef enum OPERAND_NUM_COMPONENTS


### PR DESCRIPTION
Note: processing of INDEX_IMMEDIATE64_PLUS_RELATIVE will still fail later in an Assert(0) but that's better than silently mistaking it for OPERAND_INDEX_IMMEDIATE32